### PR TITLE
Eliminate do_div, floating point and malloc()

### DIFF
--- a/si5351.h
+++ b/si5351.h
@@ -174,32 +174,6 @@
 #define  SI5351_XTAL_ENABLE				(1<<6)
 #define  SI5351_MULTISYNTH_ENABLE		(1<<4)
 
-/* Macro definitions */
-
-/*
- * Based on former asm-ppc/div64.h and asm-m68knommu/div64.h
- *
- * The semantics of do_div() are:
- *
- * uint32_t do_div(uint64_t *n, uint32_t base)
- * {
- *      uint32_t remainder = *n % base;
- *      *n = *n / base;
- *      return remainder;
- * }
- *
- * NOTE: macro parameter n is evaluated multiple times,
- *       beware of side effects!
- */
-
-# define do_div(n,base) ({                                      \
-        uint32_t __base = (base);                               \
-        uint32_t __rem;                                         \
-        __rem = ((uint64_t)(n)) % __base;                       \
-        (n) = ((uint64_t)(n)) / __base;                         \
-        __rem;                                                  \
- })
-
 /* Enum definitions */
 
 /*


### PR DESCRIPTION
Perhaps you'd like to try these changes, which probably reduce the AVR binary size quite a bit
and perhaps improve performance. I admit I have not yet compiled or tested them on AVR; they're
derived from a PSoC 5LP variation I'm working with.

Replace floating point with fixed-point.
Eliminate use of do_div() macro.
Use 64-bit long long types for above.
Refactor frequency programming; eliminate malloc/free.
 Note also that I've tweaked the handling of PLLB and CLK1/CLK2; not sure that's exactly right yet but
going to test it.

These changes are directly derived from code that's working on PSoC 5LP, modulo different I2C
API.
